### PR TITLE
Add Tailscale setup and MCP config generation

### DIFF
--- a/knowledge/setup/03-tailscale.md
+++ b/knowledge/setup/03-tailscale.md
@@ -1,0 +1,61 @@
+# Tailscale Setup
+
+Enable secure remote access to Machina via Tailscale.
+
+## Prerequisites
+
+- Tailscale installed and connected
+- Machina gateway running on port 8080
+
+## Enable Tailscale Serve
+
+Tailscale Serve provides HTTPS termination for your MCP server.
+
+```bash
+tailscale serve --bg http://localhost:8080
+```
+
+If you see "Serve is not enabled on your tailnet", visit the provided URL to enable it
+in your Tailscale admin console.
+
+## Verify
+
+Check serve status:
+
+```bash
+tailscale serve status
+```
+
+Should show:
+
+```
+https://<your-hostname>.ts.net/ (Funnel off)
+|-- / proxy http://127.0.0.1:8080
+```
+
+## Test Remote Access
+
+From another device on your Tailscale network:
+
+```bash
+curl https://<your-hostname>.ts.net/health
+```
+
+Should return `{"status":"ok","version":"1.0.0"}`.
+
+## Public Access (Optional)
+
+If you need access from outside your Tailscale network, enable Funnel:
+
+```bash
+tailscale funnel --bg 443
+```
+
+This exposes your MCP server publicly. The bearer token provides authentication.
+
+## Security Notes
+
+- HTTP over Tailscale is already encrypted (WireGuard)
+- Tailscale Serve adds HTTPS for compatibility with clients that require it
+- Bearer token authentication protects the MCP endpoint
+- Tailscale ACLs can further restrict which devices can access the server

--- a/knowledge/setup/05-verification.md
+++ b/knowledge/setup/05-verification.md
@@ -6,6 +6,10 @@ After installation, verify each component works correctly.
 
 Hit the gateway health endpoint. Should return `{ "status": "ok" }`.
 
+```bash
+curl http://localhost:8080/health
+```
+
 If this fails, check:
 
 1. Gateway service running (check LaunchD status)
@@ -76,3 +80,62 @@ If verification fails:
 4. Is the service running?
 
 See `../maintenance/troubleshooting.md` for common issues.
+
+## Installation Complete - MCP Config
+
+After successful verification, generate the MCP config for external AI tools.
+
+### Get Connection Details
+
+```bash
+# Get Tailscale hostname
+TAILSCALE_HOST=$(tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//')
+
+# Get token
+MACHINA_TOKEN=$(cat ~/machina/config/.env | grep MACHINA_TOKEN | cut -d= -f2)
+
+echo "Tailscale hostname: $TAILSCALE_HOST"
+echo "Token: $MACHINA_TOKEN"
+```
+
+### MCP Config (copy this)
+
+For Claude Desktop, Cursor, or other MCP-compatible tools:
+
+```json
+{
+  "mcpServers": {
+    "machina": {
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://<TAILSCALE_HOST>/mcp",
+        "headers": {
+          "Authorization": "Bearer <MACHINA_TOKEN>"
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `<TAILSCALE_HOST>` and `<MACHINA_TOKEN>` with the values from above.
+
+### Enable Tailscale HTTPS (if not already)
+
+Run:
+
+```bash
+tailscale serve --bg http://localhost:8080
+```
+
+If prompted, visit the URL to enable Tailscale Serve on your tailnet.
+
+### Verify Remote Access
+
+From another device on your Tailscale network:
+
+```bash
+curl https://<TAILSCALE_HOST>/health
+```
+
+Should return `{"status":"ok","version":"1.0.0"}`.

--- a/knowledge/setup/README.md
+++ b/knowledge/setup/README.md
@@ -53,12 +53,13 @@ After setup completes:
 ```
 01-prerequisites.md  → Required software and permissions
 02-core-install.md   → Clone repos, create directories
+03-tailscale.md      → Remote access via Tailscale
 components/
-  ├── apple-services.md → apple-mcp setup
+  ├── apple-services.md → apple-mcp setup (deprecated, gateway handles directly)
   ├── whatsapp.md       → whatsapp-mcp setup
-  └── gateway.md        → HTTP gateway spec
+  └── gateway.md        → MCP gateway spec
 04-launchd.md        → Auto-start configuration
-05-verification.md   → Test everything works
+05-verification.md   → Test everything, get MCP config
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Add `03-tailscale.md` with Tailscale serve setup instructions
- Update `05-verification.md` to generate ready-to-copy MCP config at end of install
- Update setup README to include new file in sequence

## Changes
Installation now ends with:
1. Tailscale HTTPS serving enabled
2. A ready-to-copy MCP config for Claude Desktop, Cursor, or other MCP tools

## Test plan
- [x] Ran `tailscale serve --bg http://localhost:8080`
- [x] Verified serve status shows HTTPS proxy configured
- [x] Local health check returns OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)