### PR TITLE
Add /machina-verify skill for capability testing

### DIFF
--- a/.claude/skills/machina-verify.md
+++ b/.claude/skills/machina-verify.md
@@ -1,0 +1,115 @@
+# Machina Verify
+
+Test all Machina capabilities to verify the installation is working.
+
+## When to Use
+
+- After running "set up machina"
+- After running "update machina"
+- When troubleshooting capability issues
+- When user asks to verify or test machina
+
+## Invocation
+
+User says: `/machina-verify` or "verify machina" or "test machina capabilities"
+
+## Process
+
+Run these tests in sequence, reporting results as you go:
+
+### 1. Gateway Health
+
+```bash
+curl -s http://localhost:8080/health
+```
+
+Expected: `{"status":"ok"...}`
+
+### 2. Reminders Test
+
+Create a test reminder, verify it exists, delete it:
+
+```bash
+osascript -e '
+tell application "Reminders"
+  set targetList to list "Reminders"
+  make new reminder in targetList with properties {name:"machina-verify-test", body:"Safe to delete"}
+end tell'
+```
+
+Then verify:
+
+```bash
+osascript -e '
+tell application "Reminders"
+  set targetList to list "Reminders"
+  return (count of (reminders in targetList whose name is "machina-verify-test")) as text
+end tell'
+```
+
+Then delete:
+
+```bash
+osascript -e '
+tell application "Reminders"
+  set targetList to list "Reminders"
+  delete (first reminder in targetList whose name is "machina-verify-test")
+end tell'
+```
+
+### 3. Notes Test
+
+Create a test note, verify it exists, delete it:
+
+```bash
+osascript -e '
+tell application "Notes"
+  set targetFolder to folder "Notes"
+  make new note in targetFolder with properties {name:"machina-verify-test", body:"Safe to delete"}
+end tell'
+```
+
+Then verify and delete similarly.
+
+### 4. Messages Test
+
+Read recent messages (safe, no sending):
+
+```bash
+sqlite3 ~/Library/Messages/chat.db "SELECT text FROM message ORDER BY date DESC LIMIT 1"
+```
+
+### 5. Contacts Test
+
+Count contacts to verify access:
+
+```bash
+osascript -e 'tell application "Contacts" to return (count of people) as text'
+```
+
+## Output Format
+
+Report results like:
+
+```
+Machina Verification Results: X/5 passed
+
+✅ Gateway: Health endpoint responding
+✅ Reminders: Create/verify/delete worked
+✅ Notes: Create/verify/delete worked
+✅ Messages: Can read messages
+✅ Contacts: Can access contacts (142 found)
+
+🎉 All capabilities working!
+```
+
+Or if failures:
+
+```
+⚠️ Some capabilities need attention.
+Check System Preferences → Privacy & Security → Automation
+```
+
+## Always Clean Up
+
+If any test item was created, always attempt to delete it even if verification failed.

--- a/knowledge/setup/05-verification.md
+++ b/knowledge/setup/05-verification.md
@@ -2,6 +2,20 @@
 
 After installation, verify each component works correctly.
 
+## Offer to Verify
+
+After completing setup or update, **always ask the user** if they want to run verification:
+
+> "Setup complete! Would you like me to run a quick verification to test all capabilities?"
+
+If they agree, run the `/machina-verify` skill which tests:
+
+- Gateway health endpoint
+- Reminders (create/verify/delete)
+- Notes (create/verify/delete)
+- Messages (read recent)
+- Contacts (count access)
+
 ## Quick Health Check
 
 Hit the gateway health endpoint. Should return `{ "status": "ok" }`.


### PR DESCRIPTION
## Summary

Adds a Claude Code skill (slash command) for verifying Machina capabilities work correctly. This is offered to users after setup/update completes.

### Usage
```
/machina-verify
```
or: "verify machina", "test machina capabilities"

### What it tests

| Test | Description |
|------|-------------|
| Gateway | Health endpoint responding |
| Reminders | Create → verify exists → delete |
| Notes | Create → verify exists → delete |
| Messages | Read recent (safe, no sending) |
| Contacts | Count to verify access |

### Changes
- Added `.claude/skills/machina-verify.md` skill
- Updated verification docs to tell Claude to offer verification after setup/update

### Why a skill vs MCP operation?
- Runs locally in Claude Code, not exposed to all MCP clients
- Only needed during setup/troubleshooting, not normal operation
- Can be offered contextually after setup completes

## Test plan
- [ ] Run `/machina-verify` after setup
- [ ] Verify test items are cleaned up
- [ ] Check Claude offers verification after "set up machina"

🤖 Generated with [Claude Code](https://claude.com/claude-code)