### PR TITLE
Add contact name resolution to message operations

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1240,13 +1240,15 @@ async function formatMessagesWithNames(
     textField = "text",
   } = options;
 
-  // Collect unique handles and convert JIDs to phone numbers if needed
+  // Collect unique handles and convert WhatsApp JIDs to phone numbers if needed
   const handleToPhone = new Map<string, string>();
   for (const r of rows) {
     const rawHandle = (r as any)[handleField] as string | undefined;
     if (rawHandle && !r.is_from_me) {
-      // If it's a JID, extract the phone number
-      const phone = rawHandle.includes("@")
+      // WhatsApp JIDs are digits@domain (e.g., 15551234567@s.whatsapp.net)
+      // iMessage emails are regular emails (e.g., user@example.com)
+      // Extract phone from WhatsApp JID, otherwise use handle as-is (including emails)
+      const phone = rawHandle.match(/^\d+@/)
         ? phoneFromJid(rawHandle)
         : rawHandle;
       if (phone) {


### PR DESCRIPTION
## Summary
- Resolves phone numbers to contact names in all message operations
- Uses direct SQLite queries to Apple Contacts databases (3600+ entries cached in <100ms)
- DRY helper `formatMessagesWithNames()` works for both iMessage and WhatsApp

## Before/After
```
Before: 2026-01-12 17:26:30|+15129479757|Hello
After:  2026-01-12 17:26:30|Julianna Scruggs|Hello
```

## Operations Updated
- `messages_read`, `messages_recent`, `messages_search`, `messages_conversations`
- `whatsapp_messages`, `whatsapp_search`

## Test plan
- [x] Verified messages_recent returns contact names instead of phone numbers
- [x] Confirmed cache builds successfully (3613 entries)
- [x] Numbers not in contacts remain as-is (correct behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)